### PR TITLE
removed `is_binary` constraint from Clope.Struct.Item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.3
+* Change `Clope.Struct.Item` to accept any value not just `String` as value.
+
 # 0.1.2
 * Bugfix: removes infinite loop when initial data can not be divided into clusters
 * Uses ex_machina only in test environment

--- a/lib/clope/struct/item.ex
+++ b/lib/clope/struct/item.ex
@@ -4,5 +4,5 @@ defmodule Clope.Struct.Item do
   alias Clope.Struct.Item
   @moduledoc false
 
-  def item(value) when is_binary(value), do: %Item{value: value}
+  def item(value), do: %Item{value: value}
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Clope.Mixfile do
 
   def project do
     [app: :clope,
-     version: "0.1.2",
+     version: "0.1.3",
      elixir: "~> 1.4",
      description: "CLOPE: A Fast and Effective Clustering Algorithm for Transactional Data",
      package: [

--- a/test/clope/utils_test.exs
+++ b/test/clope/utils_test.exs
@@ -26,4 +26,8 @@ defmodule Clope.UtilsTest do
        ]}
     ] = result
   end
+  test "non-atom item values" do
+     result = [{1, [{:a}, :b]}, {2,  [:b, :c]} , {3, [:z,:y]}] |> Clope.clusterize(2)
+     assert result == [[{1, [{:a}, :b]}], [{2, [:b, :c]}], [{3, [:z, :y]}]]
+  end
 end


### PR DESCRIPTION
The usecase for this is using objects which are defined by any type like
* structs
* tuples
* atoms
As far as i have seen there are no string-specific operations done on `Item.value`